### PR TITLE
Add explicit statement in README.md for installing the required version of PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository aims to provide a playground for experimenting with various atte
 ```bash
 git clone https://github.com/pytorch-labs/attention-gym.git
 cd attention-gym
+pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu124
 pip install .
 ```
 


### PR DESCRIPTION
Fixes #47 

Installing the (nightly) 2.5.0 version of PyTorch first before the other dependencies are installed. Otherwise, the current stable version of PyTorch (2.4.1) is installed by default.

To avoid that scenario, I am adding an explicit `pip` statement to install the PyTorch 2.5.0 nightly version first before anything else.